### PR TITLE
bottle.static_file: request.get_header removes race-condition

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2691,7 +2691,9 @@ def static_file(filename, root,
     lm = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(stats.st_mtime))
     headers['Last-Modified'] = lm
 
-    ims = request.environ.get('HTTP_IF_MODIFIED_SINCE')
+    ims = request.get_header('If-Modified-Since')
+    if not ims:
+      ims = request.environ.get('HTTP_IF_MODIFIED_SINCE')
     if ims:
         ims = parse_date(ims.split(";")[0].strip())
     if ims is not None and ims >= int(stats.st_mtime):


### PR DESCRIPTION
**Context** 
When I use `bottle.run(..., server='cherrypy')`, I run it in multi-threaded mode. This results in two requests sharing the same environment.
They serve the old file with 200 in this case.
**Fix**
Getting the header from the request object first, makes the actual request being used and not the request that runs in parallel.
**Evaluation**
This is a performance improvement.
